### PR TITLE
Add basic Tetris implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,23 +57,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
+name = "bumpalo"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "cc"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets",
+]
+
+[[package]]
 name = "cli"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "common",
  "crossterm",
+ "log",
  "rand",
 ]
 
 [[package]]
 name = "common"
 version = "0.1.0"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cortex-m"
@@ -271,12 +326,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c0c35952f67de54bb584e9fd912b3023117cbafc0a77d8f3dee1fb5f572fe8"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -329,6 +416,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +443,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "panic-probe"
@@ -729,6 +831,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.38",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,6 +905,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.51.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,5 @@ resolver = "2"
 
 [workspace.dependencies]
 common = {path = "./common"}
+
+log = "0.4.20"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 
 [dependencies]
 common = {workspace = true}
+log = {workspace = true}
 
 crossterm = "0.27.0"
 rand = "0.8.5"
+chrono = "0.4.31"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,7 +6,7 @@ use std::fmt::Display;
 use std::io::{self, stdout};
 
 use common::display::{Pixel, PixelDisplay};
-use common::input::BasicInput;
+use common::input::{BasicInput, DebouncedInput};
 use common::snake::SnakeGame;
 use common::tetris::TetrisGame;
 use common::{input::Input, Game, RandomNumberSource};
@@ -104,6 +104,7 @@ fn print_events() -> io::Result<()> {
     let mut d2: ConsoleDisplay<42, 16> = ConsoleDisplay::new(); // for double buffering
 
     let mut i = BasicInput::default();
+    let mut i_debounced = DebouncedInput::default();
     let mut rng = Random { rng: thread_rng() };
 
     //let mut game = TickerGame::new();
@@ -143,8 +144,9 @@ fn print_events() -> io::Result<()> {
             last_frame_time = current_time;
 
             // double buffering to only update if the display actually changed...
+            i_debounced.update(&i);
 
-            game.update(elapsed, &i, &mut d, &mut rng);
+            game.update(elapsed, &i_debounced, &mut d, &mut rng);
 
             // update display only if concents changed
             if d.changed(&d2) {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -7,6 +7,7 @@ use std::io::{self, stdout};
 
 use common::display::{Pixel, PixelDisplay};
 use common::snake::SnakeGame;
+use common::tetris::TetrisGame;
 use common::{Game, Input, RandomNumberSource};
 use crossterm::event::{
     poll, KeyEventKind, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
@@ -94,12 +95,13 @@ impl RandomNumberSource for Random {
     }
 }
 fn print_events() -> io::Result<()> {
-    let mut d: ConsoleDisplay<16, 42> = ConsoleDisplay::new();
+    let mut d: ConsoleDisplay<42, 16> = ConsoleDisplay::new();
     let mut i = Input::default();
     let mut rng = Random { rng: thread_rng() };
 
     //let mut game = TickerGame::new();
-    let mut game: SnakeGame<16, 42> = SnakeGame::new();
+    // let mut game: SnakeGame<42, 16> = SnakeGame::new();
+    let mut game: TetrisGame<42, 16> = TetrisGame::new();
 
     let mut last_frame_time = Instant::now();
     loop {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -8,7 +8,7 @@ use std::io::{self, stdout};
 use common::display::{Pixel, PixelDisplay};
 use common::snake::SnakeGame;
 use common::tetris::TetrisGame;
-use common::{Game, Input, RandomNumberSource};
+use common::{input::Input, Game, RandomNumberSource};
 use crossterm::event::{
     poll, KeyEventKind, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
     PushKeyboardEnhancementFlags,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,6 +6,7 @@ use std::fmt::Display;
 use std::io::{self, stdout};
 
 use common::display::{Pixel, PixelDisplay};
+use common::input::BasicInput;
 use common::snake::SnakeGame;
 use common::tetris::TetrisGame;
 use common::{input::Input, Game, RandomNumberSource};
@@ -102,7 +103,7 @@ fn print_events() -> io::Result<()> {
     let mut d: ConsoleDisplay<42, 16> = ConsoleDisplay::new();
     let mut d2: ConsoleDisplay<42, 16> = ConsoleDisplay::new(); // for double buffering
 
-    let mut i = Input::default();
+    let mut i = BasicInput::default();
     let mut rng = Random { rng: thread_rng() };
 
     //let mut game = TickerGame::new();
@@ -143,7 +144,7 @@ fn print_events() -> io::Result<()> {
 
             // double buffering to only update if the display actually changed...
 
-            game.update(elapsed, i, &mut d, &mut rng);
+            game.update(elapsed, &i, &mut d, &mut rng);
 
             // update display only if concents changed
             if d.changed(&d2) {

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+log = {workspace = true}
 

--- a/common/src/display.rs
+++ b/common/src/display.rs
@@ -11,7 +11,7 @@ const NUMBER_STR_LOOKUP_100: &'static [&'static str] = &[
     "97", "98", "99", "100", ">100",
 ];
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Pixel {
     On,
     Off,

--- a/common/src/display.rs
+++ b/common/src/display.rs
@@ -21,6 +21,7 @@ pub trait PixelDisplay {
     const ROWS: usize;
     const COLUMNS: usize;
 
+    /// Sets the pixel to the desired state
     fn set_pixel(&mut self, row: usize, col: usize, value: Pixel);
 
     fn clear(&mut self) {

--- a/common/src/input.rs
+++ b/common/src/input.rs
@@ -37,3 +37,54 @@ impl Input for BasicInput {
         self.action
     }
 }
+
+#[derive(Default, Clone, Copy, Debug)]
+pub struct DebouncedInput {
+    left: bool,
+    right: bool,
+    up: bool,
+    down: bool,
+    action: bool,
+    last_left: bool,
+    last_right: bool,
+    last_up: bool,
+    last_down: bool,
+    last_action: bool,
+}
+
+impl DebouncedInput {
+    pub fn update<I: Input>(&mut self, input: &I) {
+        self.left = !self.last_left && input.left();
+        self.right = !self.last_right && input.right();
+        self.up = !self.last_up && input.up();
+        self.down = !self.last_down && input.down();
+        self.action = !self.last_action && input.action();
+
+        self.last_left = input.left();
+        self.last_right = input.right();
+        self.last_up = input.up();
+        self.last_down = input.down();
+        self.last_action = input.action();
+    }
+}
+impl Input for DebouncedInput {
+    fn left(&self) -> bool {
+        self.left
+    }
+
+    fn right(&self) -> bool {
+        self.right
+    }
+
+    fn up(&self) -> bool {
+        self.up
+    }
+
+    fn down(&self) -> bool {
+        self.down
+    }
+
+    fn action(&self) -> bool {
+        self.action
+    }
+}

--- a/common/src/input.rs
+++ b/common/src/input.rs
@@ -1,0 +1,10 @@
+
+/// A struct representing the current state of the input buttons
+#[derive(Default, Clone, Copy, Debug)]
+pub struct Input {
+    pub left: bool,
+    pub right: bool,
+    pub up: bool,
+    pub down: bool,
+    pub action: bool,
+}

--- a/common/src/input.rs
+++ b/common/src/input.rs
@@ -1,10 +1,39 @@
+pub trait Input {
+    fn left(&self) -> bool;
+    fn right(&self) -> bool;
+    fn up(&self) -> bool;
+    fn down(&self) -> bool;
+    fn action(&self) -> bool;
+}
 
 /// A struct representing the current state of the input buttons
 #[derive(Default, Clone, Copy, Debug)]
-pub struct Input {
+pub struct BasicInput {
     pub left: bool,
     pub right: bool,
     pub up: bool,
     pub down: bool,
     pub action: bool,
+}
+
+impl Input for BasicInput {
+    fn left(&self) -> bool {
+        self.left
+    }
+
+    fn right(&self) -> bool {
+        self.right
+    }
+
+    fn up(&self) -> bool {
+        self.up
+    }
+
+    fn down(&self) -> bool {
+        self.down
+    }
+
+    fn action(&self) -> bool {
+        self.action
+    }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,6 +7,7 @@ use display::PixelDisplay;
 pub mod display;
 pub mod font_monospace;
 pub mod snake;
+pub mod tetris;
 
 /// A struct representing the current state of the input buttons
 #[derive(Default, Clone, Copy, Debug)]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -20,7 +20,7 @@ pub trait Game {
     fn update(
         &mut self,
         elapsed: Duration,
-        input: input::Input,
+        input: &impl input::Input,
         display: &mut impl PixelDisplay,
         random: &mut impl RandomNumberSource,
     ) -> bool;
@@ -46,7 +46,7 @@ impl Game for TickerGame {
     fn update(
         &mut self,
         elapsed: Duration,
-        input: input::Input,
+        input: &impl input::Input,
         display: &mut impl PixelDisplay,
         _rng: &mut impl RandomNumberSource,
     ) -> bool {
@@ -57,7 +57,7 @@ impl Game for TickerGame {
 
             self.row = (self.row + 1) % display.rows();
 
-            if input.up {
+            if input.up() {
                 self.col = (self.col + 1) % display.columns();
             } else {
                 self.col = self.col.saturating_sub(1);

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -6,18 +6,9 @@ use display::PixelDisplay;
 
 pub mod display;
 pub mod font_monospace;
+pub mod input;
 pub mod snake;
 pub mod tetris;
-
-/// A struct representing the current state of the input buttons
-#[derive(Default, Clone, Copy, Debug)]
-pub struct Input {
-    pub left: bool,
-    pub right: bool,
-    pub up: bool,
-    pub down: bool,
-    pub action: bool,
-}
 
 /// Trait for system-specific generation of a seed for the random number generator
 pub trait RandomNumberSource {
@@ -29,7 +20,7 @@ pub trait Game {
     fn update(
         &mut self,
         elapsed: Duration,
-        input: Input,
+        input: input::Input,
         display: &mut impl PixelDisplay,
         random: &mut impl RandomNumberSource,
     ) -> bool;
@@ -55,7 +46,7 @@ impl Game for TickerGame {
     fn update(
         &mut self,
         elapsed: Duration,
-        input: Input,
+        input: input::Input,
         display: &mut impl PixelDisplay,
         _rng: &mut impl RandomNumberSource,
     ) -> bool {

--- a/common/src/snake.rs
+++ b/common/src/snake.rs
@@ -1,6 +1,6 @@
 use core::time::Duration;
 
-use crate::{display::Pixel, Game, Input, RandomNumberSource};
+use crate::{display::Pixel, input::Input, Game, RandomNumberSource};
 
 pub struct SnakeGame<const ROWS: usize, const COLS: usize> {
     state: State,
@@ -87,7 +87,7 @@ impl<const ROWS: usize, const COLS: usize> Game for SnakeGame<ROWS, COLS> {
     fn update(
         &mut self,
         elapsed: core::time::Duration,
-        input: crate::Input,
+        input: crate::input::Input,
         display: &mut impl crate::display::PixelDisplay,
         rng: &mut impl RandomNumberSource,
     ) -> bool {

--- a/common/src/snake.rs
+++ b/common/src/snake.rs
@@ -87,7 +87,7 @@ impl<const ROWS: usize, const COLS: usize> Game for SnakeGame<ROWS, COLS> {
     fn update(
         &mut self,
         elapsed: core::time::Duration,
-        input: crate::input::Input,
+        input: &impl crate::input::Input,
         display: &mut impl crate::display::PixelDisplay,
         rng: &mut impl RandomNumberSource,
     ) -> bool {
@@ -98,7 +98,7 @@ impl<const ROWS: usize, const COLS: usize> Game for SnakeGame<ROWS, COLS> {
             // delay for starting the game
             self.state_wait_timer += elapsed;
 
-            if input.action && self.state_wait_timer > Duration::from_millis(1000) {
+            if input.action() && self.state_wait_timer > Duration::from_millis(1000) {
                 // moving on, reset the timer (for use by the game over state)
                 self.state_wait_timer = Duration::ZERO;
 
@@ -114,7 +114,7 @@ impl<const ROWS: usize, const COLS: usize> Game for SnakeGame<ROWS, COLS> {
             // delay for leaving the game over state
             self.state_wait_timer += elapsed;
 
-            if input.action && self.state_wait_timer > Duration::from_millis(1000) {
+            if input.action() && self.state_wait_timer > Duration::from_millis(1000) {
                 *self = SnakeGame::new(); // restart by reinstantiating self ;)
             }
 
@@ -123,12 +123,16 @@ impl<const ROWS: usize, const COLS: usize> Game for SnakeGame<ROWS, COLS> {
 
         self.update_timer += elapsed;
 
-        let new_direction = match input {
-            Input { left: true, .. } => Direction::Left,
-            Input { right: true, .. } => Direction::Right,
-            Input { up: true, .. } => Direction::Up,
-            Input { down: true, .. } => Direction::Down,
-            _ => self.direction,
+        let new_direction = if input.left() {
+            Direction::Left
+        } else if input.right() {
+            Direction::Right
+        } else if input.up() {
+            Direction::Up
+        } else if input.down() {
+            Direction::Down
+        } else {
+            self.direction
         };
 
         if !new_direction.is_opposite_to(self.direction) {

--- a/common/src/tetris.rs
+++ b/common/src/tetris.rs
@@ -51,9 +51,9 @@ impl Type {
     fn pattern(self) -> &'static [(isize, isize); 4] {
         match self {
             Type::Square => &[(0, 0), (0, 1), (1, 0), (1, 1)],
-            Type::L => &[(0, 0), (1, 0), (2, 0), (2, 1)],
-            Type::T => &[(0, 0), (1, 0), (1, 1), (2, 0)],
-            Type::Line => &[(0, 0), (1, 0), (2, 0), (3, 0)],
+            Type::L => &[(-2, 0), (-1, 0), (0, 0), (0, 1)],
+            Type::T => &[(-1, 0), (0, 0), (0, 1), (1, 0)],
+            Type::Line => &[(-1, 0), (0, 0), (1, 0), (2, 0)],
         }
     }
 }
@@ -80,7 +80,6 @@ impl Rotation {
     /// Applies this rotation to a (ROW, COL) tuple
     fn apply(&self, offset: (isize, isize)) -> (isize, isize) {
         match self {
-            // TODO: make sure this is correct... (pen and paper style)
             Rotation::R0 => offset,
             Rotation::R90 => (-offset.1, offset.0),
             Rotation::R180 => (-offset.0, -offset.1),

--- a/common/src/tetris.rs
+++ b/common/src/tetris.rs
@@ -2,7 +2,8 @@ use core::time::Duration;
 
 use crate::{
     display::{Pixel, PixelDisplay},
-    Game, Input, RandomNumberSource,
+    input::Input,
+    Game, RandomNumberSource,
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -156,7 +157,7 @@ impl<const ROWS: usize, const COLS: usize> Game for TetrisGame<ROWS, COLS> {
     fn update(
         &mut self,
         elapsed: core::time::Duration,
-        input: crate::Input,
+        input: crate::input::Input,
         display: &mut impl crate::display::PixelDisplay,
         rng: &mut impl RandomNumberSource,
     ) -> bool {
@@ -216,6 +217,8 @@ impl<const ROWS: usize, const COLS: usize> Game for TetrisGame<ROWS, COLS> {
                     t.column += 1;
                 }
             }
+
+            // TODO: check for down and apply the motion there!
         }
 
         if self.update_timer > self.update_rate {

--- a/common/src/tetris.rs
+++ b/common/src/tetris.rs
@@ -157,7 +157,7 @@ impl<const ROWS: usize, const COLS: usize> Game for TetrisGame<ROWS, COLS> {
     fn update(
         &mut self,
         elapsed: core::time::Duration,
-        input: crate::input::Input,
+        input: &impl crate::input::Input,
         display: &mut impl crate::display::PixelDisplay,
         rng: &mut impl RandomNumberSource,
     ) -> bool {
@@ -168,7 +168,7 @@ impl<const ROWS: usize, const COLS: usize> Game for TetrisGame<ROWS, COLS> {
             // delay for starting the game
             self.state_wait_timer += elapsed;
 
-            if input.action && self.state_wait_timer > Duration::from_millis(1000) {
+            if input.action() && self.state_wait_timer > Duration::from_millis(1000) {
                 // moving on, reset the timer (for use by the game over state)
                 self.state_wait_timer = Duration::ZERO;
 
@@ -184,7 +184,7 @@ impl<const ROWS: usize, const COLS: usize> Game for TetrisGame<ROWS, COLS> {
             // delay for leaving the game over state
             self.state_wait_timer += elapsed;
 
-            if input.action && self.state_wait_timer > Duration::from_millis(1000) {
+            if input.action() && self.state_wait_timer > Duration::from_millis(1000) {
                 *self = TetrisGame::new(); // restart by reinstantiating self ;)
             }
 
@@ -196,7 +196,7 @@ impl<const ROWS: usize, const COLS: usize> Game for TetrisGame<ROWS, COLS> {
         // always let the user rotate the block
         if let Some(t) = &mut self.current {
             // TODO: make sure the actions are valid!
-            if input.action {
+            if input.action() {
                 // let new =
                 t.rotation.rotate_right();
                 if !Self::is_valid(t, &self.board) {
@@ -204,14 +204,14 @@ impl<const ROWS: usize, const COLS: usize> Game for TetrisGame<ROWS, COLS> {
                 }
             }
 
-            if input.right {
+            if input.right() {
                 t.column += 1;
                 if !Self::is_valid(t, &self.board) {
                     t.column -= 1;
                 }
             }
 
-            if input.left {
+            if input.left() {
                 t.column -= 1;
                 if !Self::is_valid(t, &self.board) {
                     t.column += 1;

--- a/common/src/tetris.rs
+++ b/common/src/tetris.rs
@@ -1,0 +1,115 @@
+use core::time::Duration;
+
+use crate::{display::Pixel, Game, Input, RandomNumberSource};
+
+pub struct TetrisGame<const ROWS: usize, const COLS: usize> {
+    state: State,
+    update_timer: Duration,
+    update_rate: Duration,
+    position_x: isize,
+    position_y: isize,
+    apple_position_x: isize,
+    apple_position_y: isize,
+    board: [[isize; COLS]; ROWS],
+    score: usize,
+    state_wait_timer: Duration,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum State {
+    PreStart,
+    Running,
+    GameOver,
+}
+
+impl<const ROWS: usize, const COLS: usize> TetrisGame<ROWS, COLS> {
+    pub fn new() -> Self {
+        Self {
+            state: State::PreStart,
+            update_timer: Duration::ZERO,
+            update_rate: Duration::from_millis(400),
+            position_x: COLS as isize / 2,
+            position_y: ROWS as isize / 2,
+            apple_position_x: 5,
+            apple_position_y: 5,
+            board: [[0; COLS]; ROWS],
+            score: 0,
+            state_wait_timer: Duration::ZERO,
+        }
+    }
+
+    fn reset(&mut self) {}
+}
+
+impl<const ROWS: usize, const COLS: usize> Game for TetrisGame<ROWS, COLS> {
+    fn update(
+        &mut self,
+        elapsed: core::time::Duration,
+        input: crate::Input,
+        display: &mut impl crate::display::PixelDisplay,
+        rng: &mut impl RandomNumberSource,
+    ) -> bool {
+        if self.state == State::PreStart {
+            display.clear();
+            display.draw_text(0, 0, "RDY");
+
+            // delay for starting the game
+            self.state_wait_timer += elapsed;
+
+            if input.action && self.state_wait_timer > Duration::from_millis(1000) {
+                // moving on, reset the timer (for use by the game over state)
+                self.state_wait_timer = Duration::ZERO;
+
+                self.state = State::Running;
+            }
+            return true;
+        } else if self.state == State::GameOver {
+            display.clear();
+            display.draw_text(0, 0, "DEAD");
+            display.draw_text(8, 0, "=");
+            display.draw_number(8, 10, self.score);
+
+            // delay for leaving the game over state
+            self.state_wait_timer += elapsed;
+
+            if input.action && self.state_wait_timer > Duration::from_millis(1000) {
+                *self = TetrisGame::new(); // restart by reinstantiating self ;)
+            }
+
+            return true;
+        } // else continue with the game logic
+
+        self.update_timer += elapsed;
+
+        if self.update_timer > self.update_rate {
+            self.update_timer -= self.update_rate;
+
+            // redraw
+            display.clear();
+
+            display.set_pixel(
+                self.position_y as usize,
+                self.position_x as usize,
+                Pixel::On,
+            );
+            if self.apple_position_x >= 0 {
+                display.set_pixel(
+                    self.apple_position_y as usize,
+                    self.apple_position_x as usize,
+                    Pixel::On,
+                );
+            }
+            for r in 0..ROWS {
+                for c in 0..COLS {
+                    if self.board[r][c] > 0 {
+                        display.set_pixel(r, c, Pixel::On);
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        false
+    }
+}

--- a/common/src/tetris.rs
+++ b/common/src/tetris.rs
@@ -37,6 +37,15 @@ enum Type {
     Line,
 }
 impl Type {
+    fn new_random(rng: &mut impl RandomNumberSource) -> Self {
+        match rng.next_u32() % 4 {
+            0 => Self::Square,
+            1 => Self::L,
+            2 => Self::T,
+            3 => Self::Line,
+            _ => Self::Square,
+        }
+    }
     /// Returns a list of offsets to apply for this type
     fn pattern(self) -> &'static [(isize, isize); 4] {
         match self {
@@ -57,6 +66,16 @@ enum Rotation {
 }
 
 impl Rotation {
+    fn new_random(rng: &mut impl RandomNumberSource) -> Self {
+        match rng.next_u32() % 4 {
+            0 => Self::R0,
+            1 => Self::R90,
+            2 => Self::R180,
+            3 => Self::R270,
+            _ => Self::R0,
+        }
+    }
+
     /// Applies this rotation to a (ROW, COL) tuple
     fn apply(&self, offset: (isize, isize)) -> (isize, isize) {
         match self {

--- a/pico-firmware/src/main.rs
+++ b/pico-firmware/src/main.rs
@@ -123,7 +123,7 @@ fn main() -> ! {
         let elapsed = Duration::from_millis(10);
 
         // read the input
-        let i = common::input::Input {
+        let i = common::input::BasicInput {
             left: input_left.is_low().unwrap(),
             right: input_right.is_low().unwrap(),
             up: input_up.is_low().unwrap(),
@@ -140,7 +140,7 @@ fn main() -> ! {
             i.action
         );
 
-        if game.update(elapsed, i, &mut display, &mut rng) {
+        if game.update(elapsed, &i, &mut display, &mut rng) {
             display.refresh(&mut delay, false);
         }
     }

--- a/pico-firmware/src/main.rs
+++ b/pico-firmware/src/main.rs
@@ -18,11 +18,7 @@ use panic_probe as _;
 // Uncomment the BSP you included in Cargo.toml, the rest of the code does not need to change.
 use rp_pico as bsp;
 // use sparkfun_pro_micro_rp2040 as bsp;
-use common::{
-    display::{Pixel, PixelDisplay},
-    snake::SnakeGame,
-    Game, RandomNumberSource,
-};
+use common::{snake::SnakeGame, Game, RandomNumberSource};
 
 use bsp::hal::{
     clocks::{init_clocks_and_plls, Clock},
@@ -127,7 +123,7 @@ fn main() -> ! {
         let elapsed = Duration::from_millis(10);
 
         // read the input
-        let i = common::Input {
+        let i = common::input::Input {
             left: input_left.is_low().unwrap(),
             right: input_right.is_low().unwrap(),
             up: input_up.is_low().unwrap(),


### PR DESCRIPTION
A basic version of Tetris! To create this I had to add a few other nice features:

- The CLI is now double buffered and only updates the screen when the content has changed. Returning `true`/`false` to request a display redraw is not necessary (but still in the `Trait` for now)
- Add de-bounce / edge triggering for the input.
- Enable logging in the `cli` by using the `log` create and implementing a custom `Logger` that prints to the console below the game display :fire: 