### PR TITLE
Remove return value of game update trait

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -207,7 +207,7 @@ fn print_events() -> io::Result<()> {
 
             game.update(elapsed, &i_debounced, &mut d, &mut rng);
 
-            // update display only if concents changed
+            // update display only if contents changed
             if d.changed(&d2) {
                 execute!(
                     stdout(),
@@ -250,7 +250,7 @@ fn main() -> io::Result<()> {
 
     execute!(stdout, EnterAlternateScreen)?;
     if supports_keyboard_enhancement {
-        println!("Enabling Keyboard Enhancement");
+        info!("Enabling Keyboard Enhancement");
         queue!(
             stdout,
             PushKeyboardEnhancementFlags(

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -17,13 +17,14 @@ pub trait RandomNumberSource {
 
 pub trait Game {
     /// Runs the logic of the game given the current state of the input and shows it to the display
+    /// Should always draw the current state to the display in immediate-mode like style.
     fn update(
         &mut self,
         elapsed: Duration,
         input: &impl input::Input,
         display: &mut impl PixelDisplay,
         random: &mut impl RandomNumberSource,
-    ) -> bool;
+    );
 }
 
 pub struct TickerGame {
@@ -49,7 +50,7 @@ impl Game for TickerGame {
         input: &impl input::Input,
         display: &mut impl PixelDisplay,
         _rng: &mut impl RandomNumberSource,
-    ) -> bool {
+    ) {
         self.time += elapsed;
 
         if self.time > Duration::from_millis(200) {
@@ -62,14 +63,11 @@ impl Game for TickerGame {
             } else {
                 self.col = self.col.saturating_sub(1);
             }
-
-            display.clear();
-            display.set_pixel(self.row, self.col, display::Pixel::On);
-
-            display.draw_text(0, 0, "HELLO!");
-            return true;
         }
 
-        false
+        display.clear();
+        display.set_pixel(self.row, self.col, display::Pixel::On);
+
+        display.draw_text(0, 0, "HELLO!");
     }
 }

--- a/common/src/snake.rs
+++ b/common/src/snake.rs
@@ -1,6 +1,6 @@
 use core::time::Duration;
 
-use crate::{display::Pixel, input::Input, Game, RandomNumberSource};
+use crate::{display::Pixel, Game, RandomNumberSource};
 
 pub struct SnakeGame<const ROWS: usize, const COLS: usize> {
     state: State,
@@ -79,8 +79,6 @@ impl<const ROWS: usize, const COLS: usize> SnakeGame<ROWS, COLS> {
             state_wait_timer: Duration::ZERO,
         }
     }
-
-    fn reset(&mut self) {}
 }
 
 impl<const ROWS: usize, const COLS: usize> Game for SnakeGame<ROWS, COLS> {
@@ -90,7 +88,7 @@ impl<const ROWS: usize, const COLS: usize> Game for SnakeGame<ROWS, COLS> {
         input: &impl crate::input::Input,
         display: &mut impl crate::display::PixelDisplay,
         rng: &mut impl RandomNumberSource,
-    ) -> bool {
+    ) {
         if self.state == State::PreStart {
             display.clear();
             display.draw_text(0, 0, "READY");
@@ -104,7 +102,7 @@ impl<const ROWS: usize, const COLS: usize> Game for SnakeGame<ROWS, COLS> {
 
                 self.state = State::Running;
             }
-            return true;
+            return;
         } else if self.state == State::GameOver {
             display.clear();
             display.draw_text(0, 0, "DEAD");
@@ -118,7 +116,7 @@ impl<const ROWS: usize, const COLS: usize> Game for SnakeGame<ROWS, COLS> {
                 *self = SnakeGame::new(); // restart by reinstantiating self ;)
             }
 
-            return true;
+            return;
         } // else continue with the game logic
 
         self.update_timer += elapsed;
@@ -178,7 +176,7 @@ impl<const ROWS: usize, const COLS: usize> Game for SnakeGame<ROWS, COLS> {
                 || self.position_y >= ROWS as isize
             {
                 self.state = State::GameOver;
-                return false;
+                return;
             }
 
             // check for collision with the apple
@@ -195,33 +193,29 @@ impl<const ROWS: usize, const COLS: usize> Game for SnakeGame<ROWS, COLS> {
                 // TODO: CRASH!!!
                 self.state = State::GameOver;
             }
-
-            // redraw
-            display.clear();
-
-            display.set_pixel(
-                self.position_y as usize,
-                self.position_x as usize,
-                Pixel::On,
-            );
-            if self.apple_position_x >= 0 {
-                display.set_pixel(
-                    self.apple_position_y as usize,
-                    self.apple_position_x as usize,
-                    Pixel::On,
-                );
-            }
-            for r in 0..ROWS {
-                for c in 0..COLS {
-                    if self.board[r][c] > 0 {
-                        display.set_pixel(r, c, Pixel::On);
-                    }
-                }
-            }
-
-            return true;
         }
 
-        false
+        // redraw
+        display.clear();
+
+        display.set_pixel(
+            self.position_y as usize,
+            self.position_x as usize,
+            Pixel::On,
+        );
+        if self.apple_position_x >= 0 {
+            display.set_pixel(
+                self.apple_position_y as usize,
+                self.apple_position_x as usize,
+                Pixel::On,
+            );
+        }
+        for r in 0..ROWS {
+            for c in 0..COLS {
+                if self.board[r][c] > 0 {
+                    display.set_pixel(r, c, Pixel::On);
+                }
+            }
+        }
     }
 }

--- a/common/src/tetris.rs
+++ b/common/src/tetris.rs
@@ -234,7 +234,7 @@ impl<const ROWS: usize, const COLS: usize> Game for TetrisGame<ROWS, COLS> {
         input: &impl crate::input::Input,
         display: &mut impl crate::display::PixelDisplay,
         rng: &mut impl RandomNumberSource,
-    ) -> bool {
+    ) {
         if self.state == State::PreStart {
             display.clear();
             display.draw_text(0, 0, "RDY");
@@ -248,7 +248,7 @@ impl<const ROWS: usize, const COLS: usize> Game for TetrisGame<ROWS, COLS> {
 
                 self.state = State::Running;
             }
-            return true;
+            return;
         } else if self.state == State::GameOver {
             display.clear();
             display.draw_text(0, 0, "DEAD");
@@ -262,7 +262,7 @@ impl<const ROWS: usize, const COLS: usize> Game for TetrisGame<ROWS, COLS> {
                 *self = TetrisGame::new(); // restart by reinstantiating self ;)
             }
 
-            return true;
+            return;
         } // else continue with the game logic
 
         self.update_timer += elapsed;
@@ -328,7 +328,5 @@ impl<const ROWS: usize, const COLS: usize> Game for TetrisGame<ROWS, COLS> {
                 }
             }
         }
-
-        true
     }
 }

--- a/pico-firmware/src/main.rs
+++ b/pico-firmware/src/main.rs
@@ -140,9 +140,9 @@ fn main() -> ! {
             i.action
         );
 
-        if game.update(elapsed, &i, &mut display, &mut rng) {
-            display.refresh(&mut delay, false);
-        }
+        // the display is already "double buffered" so this repeated calling should be fine!
+        game.update(elapsed, &i, &mut display, &mut rng);
+        display.refresh(&mut delay, false);
     }
 }
 


### PR DESCRIPTION
Forces the games to be redraw themselves each time, a'la "immediate mode gui". Also makes sure the pico is also using the double buffering to reduce stress on the display.